### PR TITLE
[DOCKER-27] Bump cfn-lint version

### DIFF
--- a/cfn-lint/Dockerfile
+++ b/cfn-lint/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:alpine
 
-ARG lint_version=v0.71.1
+ARG lint_version=v0.72.10
 
 RUN pip install --no-cache-dir cfn-lint==${lint_version}
 


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-lint/releases/tag/v0.72.10